### PR TITLE
Solve invalid prop `style` of type `array`

### DIFF
--- a/app/lib/components/login.jsx
+++ b/app/lib/components/login.jsx
@@ -174,11 +174,11 @@ export default class loginComponent extends React.Component {
                 }
               }
               floatingLabelText=
-                {
+                { String(
                   <div>
                     {__('Password')} <b style={{ color: 'red' }}>*</b>
                   </div>
-                } />
+                )} />
             <div style={{ width: '100%', marginBottom: '24px' }}>
               <a
                 onTouchTap={

--- a/app/lib/components/login.jsx
+++ b/app/lib/components/login.jsx
@@ -174,11 +174,11 @@ export default class loginComponent extends React.Component {
                 }
               }
               floatingLabelText=
-                { String(
+                {
                   <div>
                     {__('Password')} <b style={{ color: 'red' }}>*</b>
                   </div>
-                )} />
+                } />
             <div style={{ width: '100%', marginBottom: '24px' }}>
               <a
                 onTouchTap={

--- a/app/lib/components/login.jsx
+++ b/app/lib/components/login.jsx
@@ -167,7 +167,7 @@ export default class loginComponent extends React.Component {
               type={ textType }
               floatingLabelStyle={{ color: 'rgba(0, 0, 0, 0.498039)' }}
               underlineFocusStyle={{ borderColor: Colors.amber700 }}
-              style={[styles.basicWidth, { marginTop: '-10px' }]}
+              style={{ marginTop: '-10px', ...styles.basicWidth}}
               onChange={
                 (e)=> {
                   this.setState({ password: e.target.value });


### PR DESCRIPTION
**Assign `Object()`instead of `Array()` on  `<TextField style={}>`**
`this.prop.style` expect an `Object()` and the expansion of `{[]}` return an `Array()`.
The correct way, on ECMAScript 6, to do that is spread the `styles.basicWidth` properties on a `new Object()` 
